### PR TITLE
[TA-2337] fix`EthersProvider` getting stuck when disconnected after a long time

### DIFF
--- a/drills/ethers-typechain-contract/drill.ts
+++ b/drills/ethers-typechain-contract/drill.ts
@@ -3,8 +3,8 @@ import { BridgeDoorCommon__factory } from "@peersyst/xrp-evm-contracts";
 
 async function drill() {
     const indexer = new EthersTypechainContractIndexer("0x0FCCFB556B4aA1B44F31220AcDC8007D46514f31", BridgeDoorCommon__factory, {
-        wsUrl: "wss://ws-evm-poa-sidechain.peersyst.tech",
-        stateFilePath: "state/.ethers-typechain-contract-indexer-state.json",
+        wsUrl: "ws://168.119.63.112:8546",
+        persistState: false,
     });
     await indexer.run();
 }

--- a/drills/ethers-typechain-contract/package-lock.json
+++ b/drills/ethers-typechain-contract/package-lock.json
@@ -12,7 +12,7 @@
         },
         "../../packages/ethers/packages/typechain-contract": {
             "name": "@bloxer/ethers-typechain-contract",
-            "version": "0.0.3",
+            "version": "0.0.4",
             "license": "ISC",
             "dependencies": {
                 "@bloxer/ethers": "^0.0.2",

--- a/drills/ethers-typechain-contract/package-lock.json
+++ b/drills/ethers-typechain-contract/package-lock.json
@@ -12,11 +12,11 @@
         },
         "../../packages/ethers/packages/typechain-contract": {
             "name": "@bloxer/ethers-typechain-contract",
-            "version": "0.0.4",
+            "version": "0.0.5",
             "license": "ISC",
             "dependencies": {
-                "@bloxer/ethers": "^0.0.2",
-                "@bloxer/vanilla": "^0.0.1",
+                "@bloxer/ethers": "^0.0.3",
+                "@bloxer/vanilla": "^0.0.2",
                 "@ethersproject/providers": "^5.7.2",
                 "ethers": "5.7"
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "root",
+    "name": "bloxer",
     "version": "0.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "root",
+            "name": "bloxer",
             "version": "0.0.0",
             "workspaces": [
                 "packages/*",
@@ -10942,27 +10942,27 @@
         },
         "packages/ethers": {
             "name": "@bloxer/ethers",
-            "version": "0.0.2",
+            "version": "0.0.3",
             "license": "ISC",
             "dependencies": {
-                "@bloxer/vanilla": "^0.0.1",
+                "@bloxer/vanilla": "^0.0.2",
                 "ethers": "5.7"
             }
         },
         "packages/ethers/packages/typechain-contract": {
             "name": "@bloxer/ethers-typechain-contract",
-            "version": "0.0.4",
+            "version": "0.0.5",
             "license": "ISC",
             "dependencies": {
-                "@bloxer/ethers": "^0.0.2",
-                "@bloxer/vanilla": "^0.0.1",
+                "@bloxer/ethers": "^0.0.3",
+                "@bloxer/vanilla": "^0.0.2",
                 "@ethersproject/providers": "^5.7.2",
                 "ethers": "5.7"
             }
         },
         "packages/vanilla": {
             "name": "@bloxer/vanilla",
-            "version": "0.0.1",
+            "version": "0.0.2",
             "license": "ISC",
             "dependencies": {
                 "tslog": "^4.9.2"
@@ -10970,20 +10970,20 @@
         },
         "packages/xrpl": {
             "name": "@bloxer/xrpl",
-            "version": "0.0.1",
+            "version": "0.0.2",
             "license": "ISC",
             "dependencies": {
-                "@bloxer/vanilla": "^0.0.1",
+                "@bloxer/vanilla": "^0.0.2",
                 "xrpl": "^2.12.0-beta.0"
             }
         },
         "packages/xrpl/packages/account": {
             "name": "@bloxer/xrpl-account",
-            "version": "0.0.1",
+            "version": "0.0.2",
             "license": "ISC",
             "dependencies": {
-                "@bloxer/vanilla": "^0.0.1",
-                "@bloxer/xrpl": "^0.0.1",
+                "@bloxer/vanilla": "^0.0.2",
+                "@bloxer/xrpl": "^0.0.2",
                 "xrpl": "^2.12.0-beta.0"
             }
         },
@@ -10999,11 +10999,11 @@
         },
         "packages/xrpl/packages/ledgers": {
             "name": "@bloxer/xrpl-ledgers",
-            "version": "0.0.1",
+            "version": "0.0.2",
             "license": "ISC",
             "dependencies": {
-                "@bloxer/vanilla": "^0.0.1",
-                "@bloxer/xrpl": "^0.0.1"
+                "@bloxer/vanilla": "^0.0.2",
+                "@bloxer/xrpl": "^0.0.2"
             }
         }
     }

--- a/packages/ethers/package.json
+++ b/packages/ethers/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bloxer/ethers",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "description": "Lightweight and simple ethers indexer framework based on custom events.",
     "private": false,
     "main": "src/index.ts",
@@ -11,7 +11,7 @@
     "author": "Peersyst",
     "license": "ISC",
     "dependencies": {
-        "@bloxer/vanilla": "^0.0.1",
+        "@bloxer/vanilla": "^0.0.2",
         "ethers": "5.7"
     },
     "sideEffects": false,

--- a/packages/ethers/packages/typechain-contract/package.json
+++ b/packages/ethers/packages/typechain-contract/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bloxer/ethers-typechain-contract",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "description": "Lightweight and simple ethers typechain-contract indexer based on custom events.",
     "private": false,
     "main": "src/index.ts",
@@ -11,8 +11,8 @@
     "author": "Peersyst",
     "license": "ISC",
     "dependencies": {
-        "@bloxer/ethers": "^0.0.2",
-        "@bloxer/vanilla": "^0.0.1",
+        "@bloxer/ethers": "^0.0.3",
+        "@bloxer/vanilla": "^0.0.2",
         "@ethersproject/providers": "^5.7.2",
         "ethers": "5.7"
     },

--- a/packages/ethers/packages/typechain-contract/src/EthersTypechainContractIndexer.ts
+++ b/packages/ethers/packages/typechain-contract/src/EthersTypechainContractIndexer.ts
@@ -67,8 +67,10 @@ export class EthersTypechainContractIndexer<ContractFactory extends GenericTypec
             let events: TypechainTypedEvent<any, any>[];
             try {
                 // Get contract inside the loop because the internal provider can change between reconnects.
+                this.logger.debug(`Getting contract`);
                 const contract = await this.getContract();
                 // Timeout needed because the `queryFilter` method hangs when the provider is disconnected.
+                this.logger.debug(`Getting events`);
                 events = await timeoutPromise(contract.queryFilter({}, fromBlock, toBlock), this.config.getEventsTimeout);
             } catch (e) {
                 this.logger.error(`Error while getting events from block ${fromBlock} to block ${toBlock}: ${e}`);
@@ -77,6 +79,7 @@ export class EthersTypechainContractIndexer<ContractFactory extends GenericTypec
                 continue;
             }
 
+            this.logger.debug(`Handling events`);
             for (const event of events) {
                 // If the previous transaction has been reached the following ones can be indexed. Otherwise, it still needs to be found.
                 if (reachedPreviousTransaction) {

--- a/packages/ethers/packages/typechain-contract/src/EthersTypechainContractIndexer.ts
+++ b/packages/ethers/packages/typechain-contract/src/EthersTypechainContractIndexer.ts
@@ -67,10 +67,10 @@ export class EthersTypechainContractIndexer<ContractFactory extends GenericTypec
             let events: TypechainTypedEvent<any, any>[];
             try {
                 // Get contract inside the loop because the internal provider can change between reconnects.
-                this.logger.debug(`Getting contract`);
+                this.logger.debug(`Getting contract ${this.contractAddress}...`);
                 const contract = await this.getContract();
                 // Timeout needed because the `queryFilter` method hangs when the provider is disconnected.
-                this.logger.debug(`Getting events`);
+                this.logger.debug(`Getting events from contract ${this.contractAddress} and blocks ${fromBlock} to ${toBlock}...`);
                 events = await timeoutPromise(contract.queryFilter({}, fromBlock, toBlock), this.config.getEventsTimeout);
             } catch (e) {
                 this.logger.error(`Error while getting events from block ${fromBlock} to block ${toBlock}: ${e}`);
@@ -79,7 +79,7 @@ export class EthersTypechainContractIndexer<ContractFactory extends GenericTypec
                 continue;
             }
 
-            this.logger.debug(`Handling events`);
+            this.logger.debug(`Handling events from contract ${this.contractAddress} and blocks ${fromBlock} to ${toBlock}...`);
             for (const event of events) {
                 // If the previous transaction has been reached the following ones can be indexed. Otherwise, it still needs to be found.
                 if (reachedPreviousTransaction) {

--- a/packages/ethers/packages/typechain-contract/src/EthersTypechainContractIndexer.ts
+++ b/packages/ethers/packages/typechain-contract/src/EthersTypechainContractIndexer.ts
@@ -35,7 +35,6 @@ export class EthersTypechainContractIndexer<ContractFactory extends GenericTypec
         } as typeof this.defaultConfig);
     }
 
-    private _contract: TypechainContractInstance<ContractFactory>;
     async getContract(): Promise<TypechainContractInstance<ContractFactory>> {
         const provider = await this.getProvider();
         return provider.getContract(this.contractFactory, this.contractAddress);

--- a/packages/vanilla/package.json
+++ b/packages/vanilla/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bloxer/vanilla",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "description": "Lightweight and simple blockchain indexer framework based on custom events.",
     "private": false,
     "main": "src/index.ts",

--- a/packages/vanilla/src/Indexer.ts
+++ b/packages/vanilla/src/Indexer.ts
@@ -277,6 +277,7 @@ export abstract class Indexer<Generics extends IndexerGenerics> {
 
             if (this.reconnectRetries > this.config.maxReconnectAttempts) {
                 this.logger.error(`Could not reach ${this.config.wsUrl}`);
+                break;
             }
 
             this.logger.warn(`Reconnecting to ${this.config.wsUrl}... (${this.reconnectRetries})`);

--- a/packages/vanilla/src/Indexer.ts
+++ b/packages/vanilla/src/Indexer.ts
@@ -270,7 +270,11 @@ export abstract class Indexer<Generics extends IndexerGenerics> {
      * Reconnects the provider
      */
     private async reconnectProvider(): Promise<void> {
+        this.logger.debug(`Reconnect to ${this.config.wsUrl}`);
+
         await this._provider.disconnect();
+
+        this.logger.debug(`Disconnected from ${this.config.wsUrl} before trying to reconnect`);
 
         while (!this._provider.isConnected()) {
             this.reconnectRetries++;

--- a/packages/xrpl/package.json
+++ b/packages/xrpl/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bloxer/xrpl",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "description": "Lightweight and simple xrpl indexer framework based on custom events.",
     "private": false,
     "main": "src/index.ts",
@@ -11,7 +11,7 @@
     "author": "Peersyst",
     "license": "ISC",
     "dependencies": {
-        "@bloxer/vanilla": "^0.0.1",
+        "@bloxer/vanilla": "^0.0.2",
         "xrpl": "^2.12.0-beta.0"
     },
     "sideEffects": false,

--- a/packages/xrpl/packages/account/package.json
+++ b/packages/xrpl/packages/account/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bloxer/xrpl-account",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "description": "Lightweight and simple xrpl account indexer based on custom events.",
     "private": false,
     "main": "src/index.ts",
@@ -11,8 +11,8 @@
     "author": "Peersyst",
     "license": "ISC",
     "dependencies": {
-        "@bloxer/vanilla": "^0.0.1",
-        "@bloxer/xrpl": "^0.0.1",
+        "@bloxer/vanilla": "^0.0.2",
+        "@bloxer/xrpl": "^0.0.2",
         "xrpl": "^2.12.0-beta.0"
     },
     "sideEffects": false,

--- a/packages/xrpl/packages/ledgers/package.json
+++ b/packages/xrpl/packages/ledgers/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bloxer/xrpl-ledgers",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "description": "Lightweight and simple xrpl ledgers indexer based on custom events.",
     "private": false,
     "main": "src/index.ts",
@@ -11,8 +11,8 @@
     "author": "Peersyst",
     "license": "ISC",
     "dependencies": {
-        "@bloxer/vanilla": "^0.0.1",
-        "@bloxer/xrpl": "^0.0.1"
+        "@bloxer/vanilla": "^0.0.2",
+        "@bloxer/xrpl": "^0.0.2"
     },
     "sideEffects": false,
     "publishConfig": {


### PR DESCRIPTION
# Fix `EthersProvider` getting stuck when disconnected after a long time

## Changes

- Remove unused `_contract` variable in `EthersTypechainContractIndexer`
- Use `WebSocket.close` method directly and set `providerIsConnected` to false in `EthersProvider.disconnect`
- Bump patch version in all packages