### PR TITLE
[TA-2341] Recover pending events and last event

### DIFF
--- a/packages/ethers/packages/typechain-contract/src/EthersTypechainContractIndexer.ts
+++ b/packages/ethers/packages/typechain-contract/src/EthersTypechainContractIndexer.ts
@@ -47,15 +47,9 @@ export class EthersTypechainContractIndexer<ContractFactory extends GenericTypec
         super(EthersTypechainContractProvider, config);
     }
 
-    async index({
-        startingBlock,
-        endingBlock = this.latestBlock,
-        previousTransaction,
-    }: EthersTypechainContractIndexerIndexOptions): Promise<number> {
+    async index({ startingBlock, endingBlock }: EthersTypechainContractIndexerIndexOptions): Promise<number> {
         let fromBlock = startingBlock;
         let toBlock = Math.min(startingBlock + this.config.blocksBatchSize, endingBlock);
-        // TODO: Move to `Indexer` in https://www.notion.so/1930f38fb1e94f82845dab04ac1caeca?v=64f1d5da841741cf9cb3b831e5b493e3&p=fbd10cc7c64f44deb868638b7ac89c86&pm=s
-        let reachedPreviousTransaction = !previousTransaction;
 
         while (fromBlock <= endingBlock) {
             this.logger.info(`Indexing from block ${fromBlock} to block ${toBlock}...`);
@@ -77,14 +71,8 @@ export class EthersTypechainContractIndexer<ContractFactory extends GenericTypec
 
             this.logger.debug(`Handling events from contract ${this.contractAddress} and blocks ${fromBlock} to ${toBlock}...`);
             for (const event of events) {
-                // If the previous transaction has been reached the following ones can be indexed. Otherwise, it still needs to be found.
-                if (reachedPreviousTransaction) {
-                    // Emit event
-                    // TODO: Events are not inferred correctly here. They are when using the indexer.
-                    if (event.event) (this.notifyEvent as any)(event.event, event.transactionHash, event.blockNumber, event);
-                } else if (event.transactionHash === previousTransaction) {
-                    reachedPreviousTransaction = true;
-                }
+                // Events are not inferred correctly here. They are when using the indexer.
+                if (event.event) (this.notifyEvent as any)(event.event, event.transactionHash, event.blockNumber, event);
             }
 
             this.logger.info(`Indexed from block ${fromBlock} to block ${toBlock}...`);

--- a/packages/vanilla/src/db/entities/PendingEvent.ts
+++ b/packages/vanilla/src/db/entities/PendingEvent.ts
@@ -1,13 +1,12 @@
-import { AnyObject } from "@swisstype/essential";
 import { Entity } from "./Entity";
 
 export class PendingEvent extends Entity("pending_event") {
     event: string;
     hash: string;
     block: number;
-    data: AnyObject;
+    data: any[];
 
-    static fromEventNotification(event: string, hash: string, block: number, ...data: AnyObject[]): PendingEvent {
+    static fromEventNotification(event: string, hash: string, block: number, ...data: any[]): PendingEvent {
         return {
             event,
             hash,

--- a/packages/vanilla/src/db/repositories/DB.repository.ts
+++ b/packages/vanilla/src/db/repositories/DB.repository.ts
@@ -9,7 +9,7 @@ export abstract class DBRepository<Entity extends EntityConstructor> {
      * @param where The where clauses (will be joined with OR).
      * @returns The resource or undefined if no resource is found.
      */
-    abstract findOne(...where: Partial<InstanceOf<Entity>>[]): Promise<InstanceOf<Entity>>;
+    abstract findOne(...where: Partial<InstanceOf<Entity>>[]): Promise<InstanceOf<Entity> | undefined>;
 
     /**
      * Returns all resources from the DB matching the given wheres.

--- a/packages/vanilla/src/db/repositories/SQLDB.repository.ts
+++ b/packages/vanilla/src/db/repositories/SQLDB.repository.ts
@@ -13,7 +13,7 @@ export abstract class SQLDBRepository<Entity extends EntityConstructor> extends 
         super(entity);
     }
 
-    async findOne(...where: Partial<InstanceOf<Entity>>[]): Promise<InstanceOf<Entity>> {
+    async findOne(...where: Partial<InstanceOf<Entity>>[]): Promise<InstanceOf<Entity> | undefined> {
         const row = await this.db.get(this.sqlAdapter.buildSelect(...where));
         return row ? this.entity.fromRow(this.sqlAdapter.sqlRowToRecord(row)) : undefined;
     }

--- a/packages/vanilla/src/types.ts
+++ b/packages/vanilla/src/types.ts
@@ -10,8 +10,14 @@ export type IndexerConfig = {
     wsUrl: string;
     /**
      * The starting block to index from.
-     * */
+     * @default 0
+     */
     startingBlock?: number | undefined | "latest";
+    /**
+     * The ending block to index to.
+     * @default "latest"
+     */
+    endingBlock?: number | undefined | "latest";
     /**
      * The maximum interval in milliseconds to send a ping request to the node.
      * @default 5000
@@ -61,10 +67,6 @@ export type IndexOptions = {
      * @default "The current block."
      */
     endingBlock?: number;
-    /**
-     * The hash of the previous transaction.
-     */
-    previousTransaction?: string;
 };
 
 export type ExtendedIndexOptions<ExtendedOptions extends AnyObject | undefined = {}> = (ExtendedOptions extends undefined

--- a/packages/xrpl/packages/account/src/XrplAccountIndexer.ts
+++ b/packages/xrpl/packages/account/src/XrplAccountIndexer.ts
@@ -33,11 +33,9 @@ export class XrplAccountIndexer extends XrplIndexer<{
         super(config);
     }
 
-    async index({ startingBlock, endingBlock, previousTransaction }: XrplAccountIndexerIndexOptions): Promise<number> {
+    async index({ startingBlock, endingBlock }: XrplAccountIndexerIndexOptions): Promise<number> {
         let marker;
         let lastIndexedLedger = startingBlock;
-        // TODO: Move to `Indexer` in https://www.notion.so/1930f38fb1e94f82845dab04ac1caeca?v=64f1d5da841741cf9cb3b831e5b493e3&p=fbd10cc7c64f44deb868638b7ac89c86&pm=s
-        let reachedPreviousTransaction = !previousTransaction;
 
         do {
             const res = await this.request({
@@ -62,18 +60,13 @@ export class XrplAccountIndexer extends XrplIndexer<{
                     if (accountTx.validated && correctlyCastedAccountTx.meta.TransactionResult === "tesSUCCESS") {
                         const tx = correctlyCastedAccountTx.tx;
 
-                        // If the previous transaction has been reached the following ones can be indexed. Otherwise, it still needs to be found.
-                        if (reachedPreviousTransaction) {
-                            const hash = tx.hash;
-                            const block = tx.ledger_index;
+                        const hash = tx.hash;
+                        const block = tx.ledger_index;
 
-                            if (hash !== undefined && block !== undefined) {
-                                // Notify transaction events
-                                this.notifyEvent("Transaction", hash, block, correctlyCastedAccountTx);
-                                this.notifyEvent(tx.TransactionType, hash, block, correctlyCastedAccountTx as AccountTransaction<any>);
-                            }
-                        } else if (tx.hash === previousTransaction) {
-                            reachedPreviousTransaction = true;
+                        if (hash !== undefined && block !== undefined) {
+                            // Notify transaction events
+                            this.notifyEvent("Transaction", hash, block, correctlyCastedAccountTx);
+                            this.notifyEvent(tx.TransactionType, hash, block, correctlyCastedAccountTx as AccountTransaction<any>);
                         }
                     }
                 }

--- a/packages/xrpl/packages/ledgers/src/XrplLedgersIndexer.ts
+++ b/packages/xrpl/packages/ledgers/src/XrplLedgersIndexer.ts
@@ -23,7 +23,7 @@ export class XrplLedgersIndexer extends XrplIndexer<{
         super(config);
     }
 
-    async index({ startingBlock, endingBlock = this.latestBlock }: XrplLedgersIndexerIndexOptions): Promise<number> {
+    async index({ startingBlock, endingBlock }: XrplLedgersIndexerIndexOptions): Promise<number> {
         let currentBlock = startingBlock;
 
         while (currentBlock <= endingBlock) {

--- a/scripts/create-flavour-impl.js
+++ b/scripts/create-flavour-impl.js
@@ -141,7 +141,7 @@ export class ${implIndexerName} extends ${flavourIndexerName}<{
         super(config);
     }
 
-    async index({ startingBlock, endingBlock, previousTransaction }: ${implIndexOptionsName}): Promise<number> {}
+    async index({ startingBlock, endingBlock }: ${implIndexOptionsName}): Promise<number> {}
 }
 `;
         fse.writeFileSync(buildImplSrcPath(`${implIndexerName}.ts`), implIndexer, "utf8");


### PR DESCRIPTION
# Recover pending events and last event

## Changes
- Recover last event on `Indexer.run`
- Recover and emit penting events on `Indexer.run`
- Move `lastEvent` logic from implementations to `Indexer`
- Refactor `startingBlock` and `endingBock` in `Indexer`
- Add recover error handling in `Indexer`