### PR TITLE
Store last event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2710,6 +2710,14 @@
             "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
             "dev": true
         },
+        "node_modules/async-mutex": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.1.tgz",
+            "integrity": "sha512-WfoBo4E/TbCX1G95XTjbWTE3X2XLG0m1Xbv2cwOtuPdyH9CZvnaA5nCt1ucjaKEgW2A5IF71hxrRhr83Je5xjA==",
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -10793,8 +10801,7 @@
         "node_modules/tslib": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-            "dev": true
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/tslog": {
             "version": "4.9.2",
@@ -11490,6 +11497,7 @@
             "version": "0.0.2",
             "license": "ISC",
             "dependencies": {
+                "async-mutex": "^0.4.1",
                 "fs-extra": "^11.2.0",
                 "sqlite": "^5.1.1",
                 "sqlite3": "^5.1.7",

--- a/packages/ethers/packages/typechain-contract/src/EthersTypechainContractIndexer.ts
+++ b/packages/ethers/packages/typechain-contract/src/EthersTypechainContractIndexer.ts
@@ -75,6 +75,8 @@ export class EthersTypechainContractIndexer<ContractFactory extends GenericTypec
                 if (event.event) (this.notifyEvent as any)(event.event, event.transactionHash, event.blockNumber, event);
             }
 
+            this.notifyBlock(toBlock);
+
             this.logger.info(`Indexed from block ${fromBlock} to block ${toBlock}...`);
 
             fromBlock = toBlock + 1;

--- a/packages/vanilla/package.json
+++ b/packages/vanilla/package.json
@@ -11,6 +11,7 @@
     "author": "Peersyst",
     "license": "ISC",
     "dependencies": {
+        "async-mutex": "^0.4.1",
         "fs-extra": "^11.2.0",
         "sqlite": "^5.1.1",
         "sqlite3": "^5.1.7",

--- a/packages/vanilla/src/Indexer.ts
+++ b/packages/vanilla/src/Indexer.ts
@@ -482,7 +482,7 @@ export abstract class Indexer<Generics extends IndexerGenerics> {
     }
 
     /**
-     * Notifies the last block processed. It saves the last event only with the block if `persist` is true.
+     * Notifies the last block processed. It saves the last event only with the `block + 1` if `persist` is true.
      * This method should be called after processing a block or a batch of blocks in order to keep the persistence updated.
      * @param block The block.
      */

--- a/packages/vanilla/src/Indexer.ts
+++ b/packages/vanilla/src/Indexer.ts
@@ -435,7 +435,7 @@ export abstract class Indexer<Generics extends IndexerGenerics> {
     }
 
     /**
-     * Saves the last indexed block by saving the last event only with the block + 1.
+     * Saves the last indexed block by saving the last event only with the `block + 1`.
      * Uses a mutex to ensure that only one event is saved at a time.
      * @param block The block.
      * @returns An array containing the last event and the pending event.

--- a/packages/vanilla/src/Indexer.ts
+++ b/packages/vanilla/src/Indexer.ts
@@ -435,12 +435,12 @@ export abstract class Indexer<Generics extends IndexerGenerics> {
     }
 
     /**
-     * Saves the next block to index by saving the last event only with the block.
+     * Saves the last indexed block by saving the last event only with the block + 1.
      * Uses a mutex to ensure that only one event is saved at a time.
      * @param block The block.
      * @returns An array containing the last event and the pending event.
      */
-    private async saveNextBlock(block: number): Promise<LastEvent | void> {
+    private async saveBlock(block: number): Promise<LastEvent | void> {
         return await this.eventMutex.runExclusive(
             async () => await this.db.getRepository(LastEvent).updateOrCreate(new LastEvent(block + 1)),
         );
@@ -492,7 +492,7 @@ export abstract class Indexer<Generics extends IndexerGenerics> {
              * We assume that the last event is reached.
              * A new block can never be processed if the last event is not reached.
              */
-            this.saveNextBlock(block).catch((e) => {
+            this.saveBlock(block).catch((e) => {
                 this.logger.error(`Error while saving the last block processed ${block}: ${e}`);
             });
         }

--- a/packages/vanilla/src/db/entities/Entity.ts
+++ b/packages/vanilla/src/db/entities/Entity.ts
@@ -3,7 +3,7 @@ import { AnyObject } from "@swisstype/essential";
 export interface EntityConstructor {
     // The entity type is set to `any` since the entity class is not known at compile time.
     // A constructor function must be defined in the interface so TS understands that another class can extend it.
-    new (): any;
+    new (...args: any[]): any;
     table: string;
     fromRow(row: AnyObject): any;
     toRow(entity: any): AnyObject;

--- a/packages/vanilla/src/db/entities/LastEvent.ts
+++ b/packages/vanilla/src/db/entities/LastEvent.ts
@@ -1,7 +1,20 @@
 import { Entity } from "./Entity";
 
+/**
+ * Entity used to store the last event processed.
+ * There are 2 types of `LastEvent`:
+ * - Only `block`: Stores the upcoming block to be processed.
+ * - `block`, `event`, `hash`: Stores the last event processed. The indexer will start indexing from the next event.
+ */
 export class LastEvent extends Entity("last_event") {
-    event: string;
-    hash: string;
     block: number;
+    event?: string;
+    hash?: string;
+
+    constructor(block: number, event?: string, hash?: string) {
+        super();
+        this.event = event;
+        this.hash = hash;
+        this.block = block;
+    }
 }

--- a/packages/vanilla/src/db/entities/LastEvent.ts
+++ b/packages/vanilla/src/db/entities/LastEvent.ts
@@ -13,8 +13,8 @@ export class LastEvent extends Entity("last_event") {
 
     constructor(block: number, event?: string, hash?: string) {
         super();
+        this.block = block;
         this.event = event;
         this.hash = hash;
-        this.block = block;
     }
 }

--- a/packages/vanilla/src/db/entities/PendingEvent.ts
+++ b/packages/vanilla/src/db/entities/PendingEvent.ts
@@ -1,17 +1,19 @@
 import { Entity } from "./Entity";
 
+/**
+ * Entity used to store the pending events to be processed.
+ */
 export class PendingEvent extends Entity("pending_event") {
     event: string;
     hash: string;
     block: number;
     data: any[];
 
-    static fromEventNotification(event: string, hash: string, block: number, ...data: any[]): PendingEvent {
-        return {
-            event,
-            hash,
-            block,
-            data: data.length ? data : undefined,
-        };
+    constructor(event: string, hash: string, block: number, ...data: any[]) {
+        super();
+        this.event = event;
+        this.hash = hash;
+        this.block = block;
+        this.data = data;
     }
 }

--- a/packages/vanilla/src/db/migrations/001-init.sql
+++ b/packages/vanilla/src/db/migrations/001-init.sql
@@ -13,8 +13,7 @@ CREATE TABLE pending_event (
 CREATE TABLE last_event (
   event     TEXT,
   hash      TEXT,
-  block     INTEGER     NOT NULL,
-  PRIMARY KEY (event, hash)
+  block     INTEGER     NOT NULL
 );
 
 --------------------------------------------------------------------------------

--- a/packages/vanilla/src/db/repositories/DB.repository.ts
+++ b/packages/vanilla/src/db/repositories/DB.repository.ts
@@ -37,4 +37,12 @@ export abstract class DBRepository<Entity extends EntityConstructor> {
      * @param where The where clauses (will be joined with OR).
      */
     abstract delete(...where: Partial<InstanceOf<Entity>>[]): Promise<void>;
+
+    /**
+     * Updates a resource in the DB or creates it if it does not exist.
+     * @param data The data to update or create.
+     * @param where The where clauses (will be joined with OR).
+     * @returns The created resource if it was created, otherwise void.
+     */
+    abstract updateOrCreate(data: InstanceOf<Entity>, ...where: Partial<InstanceOf<Entity>>[]): Promise<InstanceOf<Entity> | void>;
 }

--- a/packages/vanilla/src/db/repositories/SQLDB.repository.ts
+++ b/packages/vanilla/src/db/repositories/SQLDB.repository.ts
@@ -35,4 +35,14 @@ export abstract class SQLDBRepository<Entity extends EntityConstructor> extends 
     async delete(...where: Partial<InstanceOf<Entity>>[]): Promise<void> {
         await this.db.delete(this.sqlAdapter.buildDelete(...where));
     }
+
+    async updateOrCreate(data: InstanceOf<Entity>, ...where: Partial<InstanceOf<Entity>>[]): Promise<InstanceOf<Entity> | void> {
+        const row = await this.findOne(...where);
+
+        if (row) {
+            return this.update(data, ...where);
+        } else {
+            return this.create(data);
+        }
+    }
 }

--- a/packages/vanilla/src/db/repositories/adapters/sql/SQL.adapter.ts
+++ b/packages/vanilla/src/db/repositories/adapters/sql/SQL.adapter.ts
@@ -99,7 +99,7 @@ export abstract class SQLAdapter<Entity extends EntityConstructor> {
         return this.withWhereClause(
             `UPDATE ${this.entity.table}
         SET ${Object.entries(this.entity.toRow(data))
-            .map((key, value) => `${key} = ${this.valueToSql(value)}`)
+            .map(([key, value]) => `${key} = ${this.valueToSql(value)}`)
             .join(", ")}`,
             ...where,
         );

--- a/packages/xrpl/packages/account/src/XrplAccountIndexer.ts
+++ b/packages/xrpl/packages/account/src/XrplAccountIndexer.ts
@@ -70,6 +70,8 @@ export class XrplAccountIndexer extends XrplIndexer<{
                         }
                     }
                 }
+
+                this.notifyBlock(lastIndexedLedger);
             }
         } while (marker);
 

--- a/packages/xrpl/packages/ledgers/src/XrplLedgersIndexer.ts
+++ b/packages/xrpl/packages/ledgers/src/XrplLedgersIndexer.ts
@@ -36,6 +36,7 @@ export class XrplLedgersIndexer extends XrplIndexer<{
 
             if (res.result.validated) {
                 this.notifyEvent("Ledger", res.result.ledger_hash, res.result.ledger_index, res.result.ledger as SelectedLedgerType);
+                this.notifyBlock(res.result.ledger_index);
                 ++currentBlock;
             }
 


### PR DESCRIPTION
# Store last event

## Changes

- Add `updateOrCreate` method to `DBRepository` and implement it in `SQLDBRepository`
- Small fix in `SQLAdapter.buildSetClause`
- Add `async-mutex` to perform atomic operations in the DB
- Remove primary key from `last_event` table and make `event` and `hash` nullable
- Make `event` and `hash` optional in `LastEvent` entity to allow storing only the block
- Update or create `LastEvent` when calling `notifyEvent`
- Add `notifyBlock` method to update persistance between blocks without events
- Update or create `LastEvent` when calling `notifyBlock`
- Add `notifyBlock` to flavours