### PR TITLE
[TA-2360] [VAN] Sanitize sql queries

### DIFF
--- a/drills/ethers-typechain-contract/drill.ts
+++ b/drills/ethers-typechain-contract/drill.ts
@@ -13,109 +13,70 @@ async function drill() {
             minLevel: 3,
         },
     });
-    indexer.on("AddClaimAttestation", async (event) => {
+    indexer.on("AddClaimAttestation", async (event, { event: eventKey, hash, i, block }) => {
         console.log("Found AddClaimAttestation event");
-        await appendFile(
-            "./bridge-events.txt",
-            `${event.event} ${event.transactionHash} ${event.logIndex} ${event.blockNumber} ${JSON.stringify(event)}\n`,
-        );
-        indexer.eventDone("AddClaimAttestation", event.transactionHash, event.logIndex);
+        await appendFile("./bridge-events.txt", `${eventKey} ${hash} ${i} ${block} ${JSON.stringify(event)}\n`);
+        indexer.eventDone("AddClaimAttestation", hash, i);
     });
-    indexer.on("AddCreateAccountAttestation", async (event) => {
+    indexer.on("AddCreateAccountAttestation", async (event, { event: eventKey, hash, i, block }) => {
         console.log("Found AddCreateAccountAttestation event");
-        await appendFile(
-            "./bridge-events.txt",
-            `${event.event} ${event.transactionHash} ${event.logIndex} ${event.blockNumber} ${JSON.stringify(event)}\n`,
-        );
-        indexer.eventDone("AddCreateAccountAttestation", event.transactionHash, event.logIndex);
+        await appendFile("./bridge-events.txt", `${eventKey} ${hash} ${i} ${block} ${JSON.stringify(event)}\n`);
+        indexer.eventDone("AddCreateAccountAttestation", hash, i);
     });
-    indexer.on("Claim", async (event) => {
+    indexer.on("Claim", async (event, { event: eventKey, hash, i, block }) => {
         console.log("Found Claim event");
-        await appendFile(
-            "./bridge-events.txt",
-            `${event.event} ${event.transactionHash} ${event.logIndex} ${event.blockNumber} ${JSON.stringify(event)}\n`,
-        );
-        indexer.eventDone("Claim", event.transactionHash, event.logIndex);
+        await appendFile("./bridge-events.txt", `${eventKey} ${hash} ${i} ${block} ${JSON.stringify(event)}\n`);
+        indexer.eventDone("Claim", hash, i);
     });
-    indexer.on("Commit", async (event) => {
+    indexer.on("Commit", async (event, { event: eventKey, hash, i, block }) => {
         console.log("Found Commit event");
-        await appendFile(
-            "./bridge-events.txt",
-            `${event.event} ${event.transactionHash} ${event.logIndex} ${event.blockNumber} ${JSON.stringify(event)}\n`,
-        );
-        indexer.eventDone("Commit", event.transactionHash, event.logIndex);
+        await appendFile("./bridge-events.txt", `${eventKey} ${hash} ${i} ${block} ${JSON.stringify(event)}\n`);
+        indexer.eventDone("Commit", hash, i);
     });
-    indexer.on("CommitWithoutAddress", async (event) => {
+    indexer.on("CommitWithoutAddress", async (event, { event: eventKey, hash, i, block }) => {
         console.log("Found CommitWithoutAddress event");
-        await appendFile(
-            "./bridge-events.txt",
-            `${event.event} ${event.transactionHash} ${event.logIndex} ${event.blockNumber} ${JSON.stringify(event)}\n`,
-        );
-        indexer.eventDone("CommitWithoutAddress", event.transactionHash, event.logIndex);
+        await appendFile("./bridge-events.txt", `${eventKey} ${hash} ${i} ${block} ${JSON.stringify(event)}\n`);
+        indexer.eventDone("CommitWithoutAddress", hash, i);
     });
-    indexer.on("CreateAccount", async (event) => {
+    indexer.on("CreateAccount", async (event, { event: eventKey, hash, i, block }) => {
         console.log("Found CreateAccount event");
-        await appendFile(
-            "./bridge-events.txt",
-            `${event.event} ${event.transactionHash} ${event.logIndex} ${event.blockNumber} ${JSON.stringify(event)}\n`,
-        );
-        indexer.eventDone("CreateAccount", event.transactionHash, event.logIndex);
+        await appendFile("./bridge-events.txt", `${eventKey} ${hash} ${i} ${block} ${JSON.stringify(event)}\n`);
+        indexer.eventDone("CreateAccount", hash, i);
     });
-    indexer.on("CreateAccountCommit", async (event) => {
+    indexer.on("CreateAccountCommit", async (event, { event: eventKey, hash, i, block }) => {
         console.log("Found CreateAccountCommit event");
-        await appendFile(
-            "./bridge-events.txt",
-            `${event.event} ${event.transactionHash} ${event.logIndex} ${event.blockNumber} ${JSON.stringify(event)}\n`,
-        );
-        indexer.eventDone("CreateAccountCommit", event.transactionHash, event.logIndex);
+        await appendFile("./bridge-events.txt", `${eventKey} ${hash} ${i} ${block} ${JSON.stringify(event)}\n`);
+        indexer.eventDone("CreateAccountCommit", hash, i);
     });
-    indexer.on("CreateBridge", async (event) => {
+    indexer.on("CreateBridge", async (event, { event: eventKey, hash, i, block }) => {
         console.log("Found CreateBridge event");
-        await appendFile(
-            "./bridge-events.txt",
-            `${event.event} ${event.transactionHash} ${event.logIndex} ${event.blockNumber} ${JSON.stringify(event)}\n`,
-        );
-        indexer.eventDone("CreateBridge", event.transactionHash, event.logIndex);
+        await appendFile("./bridge-events.txt", `${eventKey} ${hash} ${i} ${block} ${JSON.stringify(event)}\n`);
+        indexer.eventDone("CreateBridge", hash, i);
     });
-    indexer.on("CreateClaim", async (event) => {
+    indexer.on("CreateClaim", async (event, { event: eventKey, hash, i, block }) => {
         console.log("Found CreateClaim event");
-        await appendFile(
-            "./bridge-events.txt",
-            `${event.event} ${event.transactionHash} ${event.logIndex} ${event.blockNumber} ${JSON.stringify(event)}\n`,
-        );
-        indexer.eventDone("CreateClaim", event.transactionHash, event.logIndex);
+        await appendFile("./bridge-events.txt", `${eventKey} ${hash} ${i} ${block} ${JSON.stringify(event)}\n`);
+        indexer.eventDone("CreateClaim", hash, i);
     });
-    indexer.on("Credit", async (event) => {
+    indexer.on("Credit", async (event, { event: eventKey, hash, i, block }) => {
         console.log("Found Credit event");
-        await appendFile(
-            "./bridge-events.txt",
-            `${event.event} ${event.transactionHash} ${event.logIndex} ${event.blockNumber} ${JSON.stringify(event)}\n`,
-        );
-        indexer.eventDone("Credit", event.transactionHash, event.logIndex);
+        await appendFile("./bridge-events.txt", `${eventKey} ${hash} ${i} ${block} ${JSON.stringify(event)}\n`);
+        indexer.eventDone("Credit", hash, i);
     });
-    indexer.on("OwnershipTransferred", async (event) => {
+    indexer.on("OwnershipTransferred", async (event, { event: eventKey, hash, i, block }) => {
         console.log("Found OwnershipTransferred event");
-        await appendFile(
-            "./bridge-events.txt",
-            `${event.event} ${event.transactionHash} ${event.logIndex} ${event.blockNumber} ${JSON.stringify(event)}\n`,
-        );
-        indexer.eventDone("OwnershipTransferred", event.transactionHash, event.logIndex);
+        await appendFile("./bridge-events.txt", `${eventKey} ${hash} ${i} ${block} ${JSON.stringify(event)}\n`);
+        indexer.eventDone("OwnershipTransferred", hash, i);
     });
-    indexer.on("Paused", async (event) => {
+    indexer.on("Paused", async (event, { event: eventKey, hash, i, block }) => {
         console.log("Found Paused event");
-        await appendFile(
-            "./bridge-events.txt",
-            `${event.event} ${event.transactionHash} ${event.logIndex} ${event.blockNumber} ${JSON.stringify(event)}\n`,
-        );
-        indexer.eventDone("Paused", event.transactionHash, event.logIndex);
+        await appendFile("./bridge-events.txt", `${eventKey} ${hash} ${i} ${block} ${JSON.stringify(event)}\n`);
+        indexer.eventDone("Paused", hash, i);
     });
-    indexer.on("Unpaused", async (event) => {
+    indexer.on("Unpaused", async (event, { event: eventKey, hash, i, block }) => {
         console.log("Found Unpaused event");
-        await appendFile(
-            "./bridge-events.txt",
-            `${event.event} ${event.transactionHash} ${event.logIndex} ${event.blockNumber} ${JSON.stringify(event)}\n`,
-        );
-        indexer.eventDone("Unpaused", event.transactionHash, event.logIndex);
+        await appendFile("./bridge-events.txt", `${eventKey} ${hash} ${i} ${block} ${JSON.stringify(event)}\n`);
+        indexer.eventDone("Unpaused", hash, i);
     });
     const startDate = new Date();
     await indexer.run();

--- a/packages/vanilla/src/EventInfo.ts
+++ b/packages/vanilla/src/EventInfo.ts
@@ -1,0 +1,25 @@
+import { PendingEvent } from "./db/entities";
+
+export class EventInfo<Event extends string = string> {
+    event: Event;
+    hash: string;
+    i?: number;
+    block: number;
+
+    static fromPendingEvent<Event extends string = string>({ event, hash, i, block }: PendingEvent<Event>): EventInfo<Event> {
+        return {
+            event,
+            hash,
+            i,
+            block,
+        };
+    }
+}
+
+export type ListenerWithEventInfo<Event extends string, Listener extends (...args: any[]) => any[]> = (
+    ...args: [...Parameters<Listener>, EventInfo<Event>]
+) => ReturnType<Listener>;
+
+export type EventsWithEventInfo<EventsDef extends Record<string, (...args: any[]) => any>> = {
+    [Event in keyof EventsDef]: ListenerWithEventInfo<Event extends string ? Event : never, EventsDef[Event]>;
+};

--- a/packages/vanilla/src/db/repositories/DB.repository.ts
+++ b/packages/vanilla/src/db/repositories/DB.repository.ts
@@ -1,5 +1,6 @@
 import { EntityConstructor } from "../entities";
 import { InstanceOf } from "../../utils/types";
+import { DBWhere } from "./types";
 
 export abstract class DBRepository<Entity extends EntityConstructor> {
     constructor(protected readonly entity: Entity) {}
@@ -9,14 +10,14 @@ export abstract class DBRepository<Entity extends EntityConstructor> {
      * @param where The where clauses (will be joined with OR).
      * @returns The resource or undefined if no resource is found.
      */
-    abstract findOne(...where: Partial<InstanceOf<Entity>>[]): Promise<InstanceOf<Entity> | undefined>;
+    abstract findOne(where?: DBWhere<Entity>): Promise<InstanceOf<Entity> | undefined>;
 
     /**
      * Returns all resources from the DB matching the given wheres.
      * @param where The where clauses (will be joined with OR).
      * @returns The found resources.
      */
-    abstract findAll(...where: Partial<InstanceOf<Entity>>[]): Promise<InstanceOf<Entity>[]>;
+    abstract findAll(where?: DBWhere<Entity>): Promise<InstanceOf<Entity>[]>;
 
     /**
      * Creates a resource in the DB.
@@ -30,13 +31,13 @@ export abstract class DBRepository<Entity extends EntityConstructor> {
      * @param data The data to update.
      * @param where The where clauses (will be joined with OR).
      */
-    abstract update(data: Partial<InstanceOf<Entity>>, ...where: Partial<InstanceOf<Entity>>[]): Promise<void>;
+    abstract update(data: Partial<InstanceOf<Entity>>, where?: DBWhere<Entity>): Promise<void>;
 
     /**
      * Deletes a resource from the DB.
      * @param where The where clauses (will be joined with OR).
      */
-    abstract delete(...where: Partial<InstanceOf<Entity>>[]): Promise<void>;
+    abstract delete(where?: DBWhere<Entity>): Promise<void>;
 
     /**
      * Updates a resource in the DB or creates it if it does not exist.
@@ -44,5 +45,5 @@ export abstract class DBRepository<Entity extends EntityConstructor> {
      * @param where The where clauses (will be joined with OR).
      * @returns The created resource if it was created, otherwise void.
      */
-    abstract updateOrCreate(data: InstanceOf<Entity>, ...where: Partial<InstanceOf<Entity>>[]): Promise<InstanceOf<Entity> | void>;
+    abstract updateOrCreate(data: Partial<InstanceOf<Entity>>, where?: DBWhere<Entity>): Promise<InstanceOf<Entity> | void>;
 }

--- a/packages/vanilla/src/db/repositories/SQLDB.repository.ts
+++ b/packages/vanilla/src/db/repositories/SQLDB.repository.ts
@@ -3,6 +3,7 @@ import { InstanceOf } from "../../utils/types";
 import { DBRepository } from "./DB.repository";
 import { DBAdapter } from "./adapters/db/interfaces";
 import { SQLAdapter } from "./adapters/sql";
+import { DBWhere } from "./types";
 
 export abstract class SQLDBRepository<Entity extends EntityConstructor> extends DBRepository<Entity> {
     constructor(
@@ -13,36 +14,41 @@ export abstract class SQLDBRepository<Entity extends EntityConstructor> extends 
         super(entity);
     }
 
-    async findOne(...where: Partial<InstanceOf<Entity>>[]): Promise<InstanceOf<Entity> | undefined> {
-        const row = await this.db.get(this.sqlAdapter.buildSelect(...where));
+    async findOne(where?: DBWhere<Entity>): Promise<InstanceOf<Entity> | undefined> {
+        const [query, parameters] = this.sqlAdapter.buildSelect(where);
+        const row = await this.db.get(query, parameters);
         return row ? this.entity.fromRow(this.sqlAdapter.sqlRowToRecord(row)) : undefined;
     }
 
-    async findAll(...where: Partial<InstanceOf<Entity>>[]): Promise<InstanceOf<Entity>[]> {
-        const rows = await this.db.all(this.sqlAdapter.buildSelect(...where));
+    async findAll(where?: DBWhere<Entity>): Promise<InstanceOf<Entity>[]> {
+        const [query, parameters] = this.sqlAdapter.buildSelect(where);
+        const rows = await this.db.all(query, parameters);
         return rows.map((row) => this.entity.fromRow(this.sqlAdapter.sqlRowToRecord(row)));
     }
 
     async create(data: InstanceOf<Entity>): Promise<InstanceOf<Entity>> {
-        await this.db.create(this.sqlAdapter.buildInsert(data));
+        const [query, parameters] = this.sqlAdapter.buildInsert(data);
+        await this.db.create(query, parameters);
         return data;
     }
 
-    async update(data: Partial<InstanceOf<Entity>>, ...where: Partial<InstanceOf<Entity>>[]): Promise<void> {
-        await this.db.update(this.sqlAdapter.buildSetClause(data, ...where));
+    async update(data: Partial<InstanceOf<Entity>>, where: DBWhere<Entity>): Promise<void> {
+        const [query, parameters] = this.sqlAdapter.buildSetClause(data, where);
+        await this.db.update(query, parameters);
     }
 
-    async delete(...where: Partial<InstanceOf<Entity>>[]): Promise<void> {
-        await this.db.delete(this.sqlAdapter.buildDelete(...where));
+    async delete(where?: DBWhere<Entity>): Promise<void> {
+        const [query, parameters] = this.sqlAdapter.buildDelete(where);
+        await this.db.delete(query, parameters);
     }
 
-    async updateOrCreate(data: InstanceOf<Entity>, ...where: Partial<InstanceOf<Entity>>[]): Promise<InstanceOf<Entity> | void> {
-        const row = await this.findOne(...where);
+    async updateOrCreate(data: Partial<InstanceOf<Entity>>, where?: DBWhere<Entity>): Promise<InstanceOf<Entity> | void> {
+        const row = await this.findOne(where);
 
         if (row) {
-            return this.update(data, ...where);
+            return this.update(data, where);
         } else {
-            return this.create(data);
+            return this.create(data as InstanceOf<Entity>);
         }
     }
 }

--- a/packages/vanilla/src/db/repositories/adapters/db/SQLiteDB.adapter.ts
+++ b/packages/vanilla/src/db/repositories/adapters/db/SQLiteDB.adapter.ts
@@ -1,6 +1,7 @@
 import { AnyObject } from "@swisstype/essential";
 import { DBAdapter } from "./interfaces";
 import { Database } from "sqlite";
+import { DBQueryParameters } from "../../types";
 
 /**
  * Implements the `DBAdapter` for an SQLite database.
@@ -8,23 +9,23 @@ import { Database } from "sqlite";
 export class SQLiteDBAdapter implements DBAdapter {
     constructor(private readonly db: Database) {}
 
-    get(query: string): Promise<AnyObject | undefined> {
-        return this.db.get(query);
+    get(query: string, parameters?: DBQueryParameters): Promise<AnyObject | undefined> {
+        return this.db.get(query, parameters);
     }
 
-    all(query: string): Promise<AnyObject[]> {
-        return this.db.all(query);
+    all(query: string, parameters?: DBQueryParameters): Promise<AnyObject[]> {
+        return this.db.all(query, parameters);
     }
 
-    async create(query: string): Promise<void> {
-        await this.db.run(query);
+    async create(query: string, parameters?: DBQueryParameters): Promise<void> {
+        await this.db.run(query, parameters);
     }
 
-    async update(query: string): Promise<void> {
-        await this.db.run(query);
+    async update(query: string, parameters?: DBQueryParameters): Promise<void> {
+        await this.db.run(query, parameters);
     }
 
-    async delete(query: string): Promise<void> {
-        await this.db.run(query);
+    async delete(query: string, parameters?: DBQueryParameters): Promise<void> {
+        await this.db.run(query, parameters);
     }
 }

--- a/packages/vanilla/src/db/repositories/adapters/db/interfaces/DB.adapter.ts
+++ b/packages/vanilla/src/db/repositories/adapters/db/interfaces/DB.adapter.ts
@@ -1,4 +1,5 @@
 import { AnyObject } from "@swisstype/essential";
+import { DBQueryParameters } from "../../../types";
 
 /**
  * DB adapters are used by repositories to interact with the database.
@@ -7,30 +8,35 @@ export interface DBAdapter {
     /**
      * Returns a single resource from the database.
      * @param query The get query to execute.
+     * @parameters The parameters to use in the query.
      */
-    get(query: string): Promise<AnyObject>;
+    get(query: string, parameters?: DBQueryParameters): Promise<AnyObject>;
 
     /**
      * Returns a list of resources from the database.
      * @param query The get query to execute.
+     * @parameters The parameters to use in the query.
      */
-    all(query: string): Promise<AnyObject[]>;
+    all(query: string, parameters?: DBQueryParameters): Promise<AnyObject[]>;
 
     /**
      * Creates a resource in the database.
      * @param query The create query to execute.
+     * @parameters The parameters to use in the query.
      */
-    create(query: string): Promise<void>;
+    create(query: string, parameters?: DBQueryParameters): Promise<void>;
 
     /**
      * Updates a resource in the database.
      * @param query The update query to execute.
+     * @parameters The parameters to use in the query.
      */
-    update(query: string): Promise<void>;
+    update(query: string, parameters?: DBQueryParameters): Promise<void>;
 
     /**
      * Deletes a resource from the database.
      * @param query The delete query to execute.
+     * @parameters The parameters to use in the query.
      */
-    delete(query: string): Promise<void>;
+    delete(query: string, parameters?: DBQueryParameters): Promise<void>;
 }

--- a/packages/vanilla/src/db/repositories/adapters/sql/SQL.adapter.ts
+++ b/packages/vanilla/src/db/repositories/adapters/sql/SQL.adapter.ts
@@ -12,9 +12,9 @@ export abstract class SQLAdapter<Entity extends EntityConstructor> {
     /**
      * Transforms a JS value to its SQL value.
      * @param value The JS value.
-     * @returns The SQL value as string.
+     * @returns The SQL value.
      */
-    abstract valueToSql<T = any>(value: T): string;
+    abstract valueToSql<T = any>(value: T): any;
 
     /**
      * Transforms an SQL value to its JS value.

--- a/packages/vanilla/src/db/repositories/adapters/sql/SQLite.adapter.ts
+++ b/packages/vanilla/src/db/repositories/adapters/sql/SQLite.adapter.ts
@@ -5,11 +5,10 @@ import { SQLAdapter } from "./SQL.adapter";
  * An SQLite adapter extended from the SQL adapter.
  */
 export class SQLiteAdapter<Entity extends EntityConstructor> extends SQLAdapter<Entity> {
-    valueToSql<T = any>(value: T): string {
-        if (typeof value === "string") return `'${value}'`;
-        else if (value === undefined || value === null) return "NULL";
-        else if (typeof value === "object") return `X'${Buffer.from(JSON.stringify(value), "utf-8").toString("hex")}'`;
-        else return value.toString();
+    valueToSql<T = any>(value: T): any {
+        if (value === undefined || value === null) return null;
+        else if (typeof value === "object") return Buffer.from(JSON.stringify(value), "utf-8");
+        else return value;
     }
 
     sqlToValue<T = any>(sqlValue: any): T {

--- a/packages/vanilla/src/db/repositories/types.ts
+++ b/packages/vanilla/src/db/repositories/types.ts
@@ -1,0 +1,18 @@
+import { InstanceOf } from "../../utils/types";
+import { EntityConstructor } from "../entities";
+
+/**
+ * Represents the parameters that can be passed to a query.
+ * @example `{ :id: 1 }` for the query `SELECT * FROM table WHERE id = :id`.
+ */
+export type DBQueryParameters = Record<`:${string}`, any>;
+
+/**
+ * Represents a where clause for a query.
+ */
+export type DBWhereClause<Entity extends EntityConstructor> = Partial<InstanceOf<Entity>>;
+
+/**
+ * Represents a where clause or an array of where clauses for a query.
+ */
+export type DBWhere<Entity extends EntityConstructor> = DBWhereClause<Entity> | DBWhereClause<Entity>[];

--- a/packages/vanilla/src/index.ts
+++ b/packages/vanilla/src/index.ts
@@ -4,3 +4,4 @@ export * from "./Provider";
 export * from "./events";
 export * from "./utils";
 export * from "./utils/types";
+export * from "./EventInfo";


### PR DESCRIPTION
# Sanitize sql queries

## Changes

- Add `types` to `repository` module with `parameters` and `where` types
- Change `where` parameters in methods to `DBWhere` instead of rest parameters
- `SQLAdapter` now returns an array with the query and parameters
- `SQLiteAdapter` now returns Javascript objects, since they are passed as parameters to the database engine