### PR TITLE
[VAN] fix: `Indexer` private variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11474,27 +11474,27 @@
         },
         "packages/ethers": {
             "name": "@bloxer/ethers",
-            "version": "1.0.0-alpha.1",
+            "version": "1.0.0-alpha.2",
             "license": "ISC",
             "dependencies": {
-                "@bloxer/vanilla": "^1.0.0-alpha.1",
+                "@bloxer/vanilla": "^1.0.0-alpha.2",
                 "ethers": "5.7"
             }
         },
         "packages/ethers/packages/typechain-contract": {
             "name": "@bloxer/ethers-typechain-contract",
-            "version": "1.0.0-alpha.1",
+            "version": "1.0.0-alpha.2",
             "license": "ISC",
             "dependencies": {
-                "@bloxer/ethers": "^1.0.0-alpha.1",
-                "@bloxer/vanilla": "^1.0.0-alpha.1",
+                "@bloxer/ethers": "^1.0.0-alpha.2",
+                "@bloxer/vanilla": "^1.0.0-alpha.2",
                 "@ethersproject/providers": "^5.7.2",
                 "ethers": "5.7"
             }
         },
         "packages/vanilla": {
             "name": "@bloxer/vanilla",
-            "version": "1.0.0-alpha.1",
+            "version": "1.0.0-alpha.2",
             "license": "ISC",
             "dependencies": {
                 "async-mutex": "^0.4.1",
@@ -11510,20 +11510,20 @@
         },
         "packages/xrpl": {
             "name": "@bloxer/xrpl",
-            "version": "1.0.0-alpha.1",
+            "version": "1.0.0-alpha.2",
             "license": "ISC",
             "dependencies": {
-                "@bloxer/vanilla": "^1.0.0-alpha.1",
+                "@bloxer/vanilla": "^1.0.0-alpha.2",
                 "xrpl": "^2.12.0-beta.0"
             }
         },
         "packages/xrpl/packages/account": {
             "name": "@bloxer/xrpl-account",
-            "version": "1.0.0-alpha.1",
+            "version": "1.0.0-alpha.2",
             "license": "ISC",
             "dependencies": {
-                "@bloxer/vanilla": "^1.0.0-alpha.1",
-                "@bloxer/xrpl": "^1.0.0-alpha.1",
+                "@bloxer/vanilla": "^1.0.0-alpha.2",
+                "@bloxer/xrpl": "^1.0.0-alpha.2",
                 "xrpl": "^2.12.0-beta.0"
             }
         },
@@ -11539,11 +11539,11 @@
         },
         "packages/xrpl/packages/ledgers": {
             "name": "@bloxer/xrpl-ledgers",
-            "version": "1.0.0-alpha.1",
+            "version": "1.0.0-alpha.2",
             "license": "ISC",
             "dependencies": {
-                "@bloxer/vanilla": "^1.0.0-alpha.1",
-                "@bloxer/xrpl": "^1.0.0-alpha.1"
+                "@bloxer/vanilla": "^1.0.0-alpha.2",
+                "@bloxer/xrpl": "^1.0.0-alpha.2"
             }
         }
     }

--- a/packages/ethers/package.json
+++ b/packages/ethers/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bloxer/ethers",
-    "version": "1.0.0-alpha.1",
+    "version": "1.0.0-alpha.2",
     "description": "Lightweight and simple ethers indexer framework based on custom events.",
     "private": false,
     "main": "src/index.ts",
@@ -11,7 +11,7 @@
     "author": "Peersyst",
     "license": "ISC",
     "dependencies": {
-        "@bloxer/vanilla": "^1.0.0-alpha.1",
+        "@bloxer/vanilla": "^1.0.0-alpha.2",
         "ethers": "5.7"
     },
     "sideEffects": false,

--- a/packages/ethers/packages/typechain-contract/package.json
+++ b/packages/ethers/packages/typechain-contract/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bloxer/ethers-typechain-contract",
-    "version": "1.0.0-alpha.1",
+    "version": "1.0.0-alpha.2",
     "description": "Lightweight and simple ethers typechain-contract indexer based on custom events.",
     "private": false,
     "main": "src/index.ts",
@@ -11,8 +11,8 @@
     "author": "Peersyst",
     "license": "ISC",
     "dependencies": {
-        "@bloxer/ethers": "^1.0.0-alpha.1",
-        "@bloxer/vanilla": "^1.0.0-alpha.1",
+        "@bloxer/ethers": "^1.0.0-alpha.2",
+        "@bloxer/vanilla": "^1.0.0-alpha.2",
         "@ethersproject/providers": "^5.7.2",
         "ethers": "5.7"
     },

--- a/packages/vanilla/package.json
+++ b/packages/vanilla/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bloxer/vanilla",
-    "version": "1.0.0-alpha.1",
+    "version": "1.0.0-alpha.2",
     "description": "Lightweight and simple blockchain indexer framework based on custom events.",
     "private": false,
     "main": "src/index.ts",

--- a/packages/vanilla/src/Indexer.ts
+++ b/packages/vanilla/src/Indexer.ts
@@ -130,12 +130,12 @@ export abstract class Indexer<Generics extends IndexerGenerics> {
     /**
      * The last event processed before the indexer is started.
      */
-    lastEvent: LastEvent | undefined;
+    private lastEvent: LastEvent | undefined;
 
     /**
      * Whether the last event has been reached and new events can be processed.
      */
-    reachedLastEvent = false;
+    private reachedLastEvent = false;
 
     /**
      * Requests the provider with retries

--- a/packages/xrpl/package.json
+++ b/packages/xrpl/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bloxer/xrpl",
-    "version": "1.0.0-alpha.1",
+    "version": "1.0.0-alpha.2",
     "description": "Lightweight and simple xrpl indexer framework based on custom events.",
     "private": false,
     "main": "src/index.ts",
@@ -11,7 +11,7 @@
     "author": "Peersyst",
     "license": "ISC",
     "dependencies": {
-        "@bloxer/vanilla": "^1.0.0-alpha.1",
+        "@bloxer/vanilla": "^1.0.0-alpha.2",
         "xrpl": "^2.12.0-beta.0"
     },
     "sideEffects": false,

--- a/packages/xrpl/packages/account/package.json
+++ b/packages/xrpl/packages/account/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bloxer/xrpl-account",
-    "version": "1.0.0-alpha.1",
+    "version": "1.0.0-alpha.2",
     "description": "Lightweight and simple xrpl account indexer based on custom events.",
     "private": false,
     "main": "src/index.ts",
@@ -11,8 +11,8 @@
     "author": "Peersyst",
     "license": "ISC",
     "dependencies": {
-        "@bloxer/vanilla": "^1.0.0-alpha.1",
-        "@bloxer/xrpl": "^1.0.0-alpha.1",
+        "@bloxer/vanilla": "^1.0.0-alpha.2",
+        "@bloxer/xrpl": "^1.0.0-alpha.2",
         "xrpl": "^2.12.0-beta.0"
     },
     "sideEffects": false,

--- a/packages/xrpl/packages/ledgers/package.json
+++ b/packages/xrpl/packages/ledgers/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bloxer/xrpl-ledgers",
-    "version": "1.0.0-alpha.1",
+    "version": "1.0.0-alpha.2",
     "description": "Lightweight and simple xrpl ledgers indexer based on custom events.",
     "private": false,
     "main": "src/index.ts",
@@ -11,8 +11,8 @@
     "author": "Peersyst",
     "license": "ISC",
     "dependencies": {
-        "@bloxer/vanilla": "^1.0.0-alpha.1",
-        "@bloxer/xrpl": "^1.0.0-alpha.1"
+        "@bloxer/vanilla": "^1.0.0-alpha.2",
+        "@bloxer/xrpl": "^1.0.0-alpha.2"
     },
     "sideEffects": false,
     "publishConfig": {


### PR DESCRIPTION
# [VAN] fix: `Indexer` private variables

## Changes

- Make `lastEvent` and `reachedLastEvent` variables private in `Indexer`